### PR TITLE
Fixed bug with navbar elements linked to parent directory

### DIFF
--- a/web/common/navbar.php
+++ b/web/common/navbar.php
@@ -3,16 +3,16 @@
   <div class='container-fluid'>
     <div class='navbar-header'>
       <!-- Optional TODO: Add dinen icon. -->
-      <a class='navbar-brand' href='../index.php'>Dinen</a>
+      <a class='navbar-brand' href='index.php'>Dinen</a>
     </div>
     <ul class='nav navbar-nav'>
-      <li><a href='../index.php'>Home</a></li>
+      <li><a href='index.php'>Home</a></li>
       <li><a href='#'>Business</a></li>
       <li><a href='#'>Customers</a></li>
     </ul>
     <ul class='nav navbar-nav navbar-right'>
-      <li><a href ='../login.php'>Login</a></li>
-      <li><a href ='../register.php'>Sign up</a></li>
+      <li><a href ='login.php'>Login</a></li>
+      <li><a href ='register.php'>Sign up</a></li>
     </ul>
   </div>
 </nav>

--- a/web/php_scripts/login.php
+++ b/web/php_scripts/login.php
@@ -23,7 +23,7 @@ function login() {
   $_SESSION['user'] = $email;
   $_SESSION['manager_id'] = $user[0];
   $_SESSION['name'] = $user[1];
-  header('Location: ../restaurants.php');
+  header('Location: restaurants.php');
   $stmt->close(); $mysqli->close();
   return 'Success.';
 }


### PR DESCRIPTION
It seems that even though navbar and php elements are located in web/common and web/php_scripts, as they get included in resulting html / php code, they point at the parent instead of current directory